### PR TITLE
Prevent duplicate symbols, use extern

### DIFF
--- a/src/poaV2/black_flag.h
+++ b/src/poaV2/black_flag.h
@@ -236,8 +236,8 @@ int black_flag(int bug_level,
 	       int sourceline,
 	       char sourcefile_revision[]);
 
-char *Program_name;
-char *Program_version;
+extern char *Program_name;
+extern char *Program_version;
 
 void black_flag_init(char progname[],char progversion[]);
 void black_flag_init_args(int narg,char *arg[],char progversion[]);


### PR DESCRIPTION
I'm performing a migration of all Bioconda packages to new compilers at the moment and found that conduit has some issues with duplicate symbols:

```
2021-03-31T19:56:13.2219350Z 19:56:13 BIOCONDA INFO (ERR) duplicate symbol '_Program_version' in:
2021-03-31T19:56:13.2220970Z 19:56:13 BIOCONDA INFO (ERR)     src/poaV2/align_score.o
2021-03-31T19:56:13.2222460Z 19:56:13 BIOCONDA INFO (ERR)     src/poaV2/liblpo.a(black_flag.o)
```

There are a couple things in a header that should be extern. That hadn't previously caused issues, since older clang versions passed `-fcommon` by default to work around these issues. As of clang 11 this is no longer the case.